### PR TITLE
Added option to query topic names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # bag2matlab
 This repo has Matlab and Python code for reading data from a ROS bag file directly into a Matlab workspace. See the documentation for bagReader.m for information on how to use the code. This requires Matlab and ROS to run. Tested with ROS Kinetic Kame and Matlab R2015b.
 
-This tool is invoked from with Matlab. Simply call bagReader.m with the bag name and the topic to read to get all of the data from that topic as a table. For example, bagReader('flight.bag', '/uav/pose') will read all of the data published on the '/uav/pose' topic that is stored within 'flight.bag'.
+This tool is invoked from with Matlab. Simply call bagReader.m with the bag name and the topic to read to get all of the data from that topic as a table. For example, `bagReader('flight.bag', '/uav/pose')` will read all of the data published on the '/uav/pose' topic that is stored within 'flight.bag'. Calling `bagReader` with only the first argument (bag name) returns a list of available topics in the bag as a table.

--- a/bagReader.m
+++ b/bagReader.m
@@ -1,6 +1,9 @@
 function [bag_data] = bagReader(bag_file, varargin)
 % BAGREADER Reads messages from a ROS bag file
 %	Usage: 
+%   bag_data = BAGREADER(bag_file) returns a table of all available topics
+%     in the bag 'bag_file'.
+%
 %   bag_data = BAGREADER(bag_file, topic_name) returns a table of all 
 %     the data published on the topic 'topic_name' in the bag 'bag_file'.
 %

--- a/bagTopicList.m
+++ b/bagTopicList.m
@@ -1,0 +1,18 @@
+function [topic_list] = bagTopicList( bag_file )
+% Function to query only the list of topics from a bag file
+% INPUT:
+%       bag_file: name of the bag file
+% RETURNS:
+%       topic_list: a table of list of topics-names.
+%
+% Note: the returned variable is a table to conform with the return-type of
+% the parent bagReader function that calls this one. Also, this allows for
+% addition of more variables (like topic attributes) to the table, if some
+% substantially crazy individual feels the need to.
+
+    % Call the Python function
+	topic_list = py.matlab_bag_helper.display_bag_topics( bag_file );
+    % Split the returned py.list to cell-array of py.list,
+    % convert those to cell-array of chars, and the final cells to a table.
+    topic_list = cell2table( cellfun( @char, cell(topic_list), 'UniformOutput', false )', 'VariableNames', {'Topics'} );
+end

--- a/matlab_bag_helper.py
+++ b/matlab_bag_helper.py
@@ -89,6 +89,38 @@ def extract_topic_data(msg):
     # Return the dictionary representing all of the fields and their information in this message
     return data
 
+def display_bag_topics( bag_file ):
+	""" Query the topic names in a bag file.
+	
+	 AJ: this gets called to display topics in a bag when no topics are specified from the original Matlab call.
+	 
+	 	-- Uses YAML to extract all information from a bag file, similar to the cmd line "rosbag info",
+	 		then loops through the returned dictionary to get topic names.
+	 NOTE TO HUMANS FROM THE FUTURE:
+	 The returned dictionary has more information such as message name, type, frequency and number.
+	 I have neither the time, nor the need for any of those .. yet ..
+	 
+	 Args:
+	 	bag_file: name of the bag file.
+	 Returns:
+	 	a list of Python strings.
+	 
+	 """
+	bag = rosbag.Bag( bag_file );
+	
+	# Get a convoluted dictionary of lists of dictionaries. Awesome.
+	topic_dict = yaml.load( bag._get_yaml_info() );
+	
+	# Create a list of strings
+	topic_list = [];
+	
+	# Fill in the topic names from the extracted dictionary.
+	# I'm pretty sure there's an easier way of doing this without a loop.
+	# 	.. I shall await the ancient wisdom of some Python wizard ..
+	for topic_num in range( len(topic_dict['topics']) ):
+		topic_list.append( topic_dict['topics'][topic_num]['topic'] );
+	return topic_list
+		
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
User can now call `bagReader` with just the bag name and have a list of topic names returned as a table.

@danthony06 Does this break either of the asserts following the `parse()`? I'm not sure what the `7` and `2` represent.
